### PR TITLE
Fix data races

### DIFF
--- a/test/fake_test.go
+++ b/test/fake_test.go
@@ -46,6 +46,14 @@ func TestConcurrentSafety(t *testing.T) {
 		go func() {
 			for j := 0; j < 1000; j++ {
 				fake.FirstName()
+				fake.LastName()
+				fake.Gender()
+				fake.FullName()
+				fake.Day()
+				fake.Country()
+				fake.Company()
+				fake.Industry()
+				fake.Street()
 			}
 			doneChan <- struct{}{}
 		}()

--- a/test/fake_test.go
+++ b/test/fake_test.go
@@ -35,3 +35,23 @@ func TestFakerRuWithCallback(t *testing.T) {
 		t.Error("Fake call for name with no samples with callback should not return blank string")
 	}
 }
+
+// TestConcurrentSafety runs fake methods in multiple go routines concurrently.
+// This test should be run with the race detector enabled.
+func TestConcurrentSafety(t *testing.T) {
+	workerCount := 10
+	doneChan := make(chan struct{})
+
+	for i := 0; i < workerCount; i++ {
+		go func() {
+			for j := 0; j < 1000; j++ {
+				fake.FirstName()
+			}
+			doneChan <- struct{}{}
+		}()
+	}
+
+	for i := 0; i < workerCount; i++ {
+		<-doneChan
+	}
+}


### PR DESCRIPTION
fake was not safe to call concurrently from multiple Go routines. This pull request contains two fixes.
1. Use concurrency safe random number generator
2. Use mutex for lookup
