### PR TITLE
Adding ipv6 support

### DIFF
--- a/internet.go
+++ b/internet.go
@@ -1,7 +1,7 @@
 package fake
 
 import (
-	"strconv"
+	"net"
 	"strings"
 
 	"github.com/corpix/uarand"
@@ -53,11 +53,22 @@ func DomainZone() string {
 
 // IPv4 generates IPv4 address
 func IPv4() string {
-	ip := make([]string, 4)
-	for i := 0; i < 4; i++ {
-		ip[i] = strconv.Itoa(r.Intn(256))
+	size := 4
+	ip := make([]byte, size)
+	for i := 0; i < size; i++ {
+		ip[i] = byte(r.Intn(256))
 	}
-	return strings.Join(ip, ".")
+	return net.IP(ip).To4().String()
+}
+
+// IPv6 generates IPv6 address
+func IPv6() string {
+	size := 16
+	ip := make([]byte, size)
+	for i := 0; i < size; i++ {
+		ip[i] = byte(r.Intn(256))
+	}
+	return net.IP(ip).To16().String()
 }
 
 // UserAgent generates a random user agent.

--- a/test/internet_test.go
+++ b/test/internet_test.go
@@ -54,5 +54,10 @@ func TestInternet(t *testing.T) {
 		if v == "" {
 			t.Errorf("UserAgent failed with lang %s", lang)
 		}
+
+		v = fake.IPv6()
+		if v == "" {
+			t.Errorf("IPv6 failed with lang %s", lang)
+		}
 	}
 }


### PR DESCRIPTION
I have also improved `IPv4` func to use `net.IP` byte slice instead of strings.