### PR TITLE
Add Seed function

### DIFF
--- a/fake.go
+++ b/fake.go
@@ -64,6 +64,12 @@ var (
 	ErrNoSamplesFn = func(lang string) error { return fmt.Errorf("No samples found for language: %s", lang) }
 )
 
+// Seed uses the provided seed value to initialize the internal PRNG to a
+// deterministic state.
+func Seed(seed int64) {
+	r.Seed(seed)
+}
+
 // GetLangs returns a slice of available languages
 func GetLangs() []string {
 	var langs []string


### PR DESCRIPTION
This PR makes it possible to inject a seed to the used PRNG.

I would have preferred if the `fake` package would just use the global `rand.Rand` so calling `rand.Seed(…)` would be enough but I suppose its to late for this change now.
