### PR TITLE
fix data race in function generate()

### DIFF
--- a/addresses.go
+++ b/addresses.go
@@ -51,6 +51,8 @@ func Street() string {
 
 // StreetAddress generates random street name along with building number
 func StreetAddress() string {
+	samplesLock.Lock()
+	defer samplesLock.Unlock()
 	return join(Street(), strconv.Itoa(r.Intn(100)))
 }
 

--- a/fake.go
+++ b/fake.go
@@ -154,7 +154,9 @@ func generate(lang, cat string, fallback bool) string {
 		if ru != '#' {
 			result += string(ru)
 		} else {
+			samplesLock.Lock()
 			result += strconv.Itoa(r.Intn(10))
+			samplesLock.Unlock()
 		}
 	}
 	return result


### PR DESCRIPTION
Hi, I've looked through the PRs and found that you've been working on solve the unsafe random number generator before. However, the problem still exists as:
```Go
func generate(lang, cat string, fallback bool) string {
	format := lookup(lang, cat+"_format", fallback)
	var result string
	for _, ru := range format {
		if ru != '#' {
			result += string(ru)
		} else {
			result += strconv.Itoa(r.Intn(10))
		}
	}
	return result
}
```
this function still remains using a global random number generator, which is unsafe if it's called concurrently. So I propose this PR to fix the problem.